### PR TITLE
Chore: 서버 응답을 공백을 기준으로 나누어 출력하지 않도록 수정

### DIFF
--- a/src/InterviewAssistant.Web/Clients/ChatApiClient.cs
+++ b/src/InterviewAssistant.Web/Clients/ChatApiClient.cs
@@ -24,7 +24,7 @@ public class ChatApiClient(HttpClient http, ILoggerFactory loggerFactory) : ICha
     private readonly ILogger<ChatApiClient> _logger = (loggerFactory ?? throw new ArgumentNullException(nameof(loggerFactory)))
                                                       .CreateLogger<ChatApiClient>();
 
-    private static readonly string loremipsum = "Lorem ipsum dolor sit amet, consectetur adipiscing elit.";
+    private static readonly string loremipsum = "Lorem ipsum dolor sit amet, \nconsectetur adipiscing elit.";
     
     /// <inheritdoc/>
     public async IAsyncEnumerable<ChatResponse> SendMessageAsync(ChatRequest request)
@@ -32,7 +32,8 @@ public class ChatApiClient(HttpClient http, ILoggerFactory loggerFactory) : ICha
         _logger.LogInformation("API 요청 시뮬레이션: {Message}", request.Messages.LastOrDefault()?.Message ?? "빈 메시지");
 
         // 하드코딩된 응답 반환
-        var responses = new[] { new ChatResponse { Message = loremipsum.Trim() } };
+        var responses = loremipsum.Split([ " ", "\r", "\n" ], StringSplitOptions.RemoveEmptyEntries)
+                                  .Select(message => new ChatResponse { Message = message.Trim() });
 
         // 응답 메시지 전송
         foreach (var response in responses)

--- a/src/InterviewAssistant.Web/Clients/ChatApiClient.cs
+++ b/src/InterviewAssistant.Web/Clients/ChatApiClient.cs
@@ -32,8 +32,7 @@ public class ChatApiClient(HttpClient http, ILoggerFactory loggerFactory) : ICha
         _logger.LogInformation("API 요청 시뮬레이션: {Message}", request.Messages.LastOrDefault()?.Message ?? "빈 메시지");
 
         // 하드코딩된 응답 반환
-        var responses = loremipsum.Split([ " ", "\r", "\n" ], StringSplitOptions.RemoveEmptyEntries)
-                                  .Select(message => new ChatResponse { Message = message.Trim() });
+        var responses = new[] { new ChatResponse { Message = loremipsum.Trim() } };
 
         // 응답 메시지 전송
         foreach (var response in responses)

--- a/src/InterviewAssistant.Web/Components/Pages/Home.razor
+++ b/src/InterviewAssistant.Web/Components/Pages/Home.razor
@@ -105,12 +105,21 @@
             
             // ChatService를 통해 응답 가져오기
             var responses = ChatService.SendMessageAsync(currentInput);
+
+            var assistantMessage = new ChatMessage { Role = MessageRoleType.Assistant, Message = string.Empty };
+            messages.Add(assistantMessage);
+
+            // 2초 동안 버퍼링 (로딩 인디케이터 유지)
+            await Task.Delay(2000);
+            isLoading = false;
+            StateHasChanged();
+
             await foreach (var response in responses)
             {
-                // 응답을 채팅 메시지로 추가
-                messages.Add(new ChatMessage { Role = MessageRoleType.Assistant, Message = response.Message });
-                StateHasChanged();
+                // 점진적으로 메시지를 추가하면서 렌더링
+                assistantMessage.Message += response.Message + " ";
                 await ScrollToBottom();
+                StateHasChanged();
             }
         }
         catch (Exception ex)


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> Chore:메인화면 응답UI 개선 #26 


## 📝 작업 내용
> 서버 응답이 공백을 기준으로 모두 끊겨 출력되는 부분 수정

### 스크린샷 (선택)


## 💬 리뷰 요구사항(선택)

> 하드코딩된 부분을 수정했는데 공백 부분을 포함해 \n, \r도 모두 지웠습니다.


## ⏰ 현재 버그


## ✏ Git Close
> close #26 
