### PR TITLE
chore: 서버 응답을 공백을 기준으로 나누어 출력하지 않도록 수정

### DIFF
--- a/src/InterviewAssistant.Web/Clients/ChatApiClient.cs
+++ b/src/InterviewAssistant.Web/Clients/ChatApiClient.cs
@@ -32,8 +32,7 @@ public class ChatApiClient(HttpClient http, ILoggerFactory loggerFactory) : ICha
         _logger.LogInformation("API 요청 시뮬레이션: {Message}", request.Messages.LastOrDefault()?.Message ?? "빈 메시지");
 
         // 하드코딩된 응답 반환
-        var responses = loremipsum.Split([ " ", "\r", "\n" ], StringSplitOptions.RemoveEmptyEntries)
-                                  .Select(message => new ChatResponse { Message = message.Trim() });
+        var responses = new[] { new ChatResponse { Message = loremipsum.Trim() } };
 
         // 응답 메시지 전송
         foreach (var response in responses)

--- a/src/InterviewAssistant.Web/Components/Pages/Home.razor
+++ b/src/InterviewAssistant.Web/Components/Pages/Home.razor
@@ -105,12 +105,18 @@
             
             // ChatService를 통해 응답 가져오기
             var responses = ChatService.SendMessageAsync(currentInput);
+
+            // 응답 메시지를 미리 추가하여 UI에서 즉시 반영될 수 있도록 함.
+            // 이후 응답이 도착하면 해당 객체의 Message 값을 업데이트함.
+            var assistantChatMessage = new ChatMessage { Role = MessageRoleType.Assistant, Message = string.Empty};
+            messages.Add(assistantChatMessage);
+
             await foreach (var response in responses)
             {
                 // 응답을 채팅 메시지로 추가
-                messages.Add(new ChatMessage { Role = MessageRoleType.Assistant, Message = response.Message });
-                StateHasChanged();
+                assistantChatMessage.Message += response.Message; 
                 await ScrollToBottom();
+                StateHasChanged(); // 메시지 변경 후 호출
             }
         }
         catch (Exception ex)


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> #26 


## 📝 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요.(이미지 첨부 가능)
- 응답이 도착할 때마다 UI를 즉시 갱신하도록 수정하여 메시지가 끊겨서 출력되지 않도록 함.

### 스크린샷 (선택)


## 💬 리뷰 요구사항(선택)

> StateHasChanged(); 가 foreach문 안에 있어도 무방할까요?


## ⏰ 현재 버그


## ✏ Git Close
> close #26 
