### PR TITLE
feat: 프론트엔드 화면에서 API연동 구현

### DIFF
--- a/src/InterviewAssistant.Web/Clients/ChatApiClient.cs
+++ b/src/InterviewAssistant.Web/Clients/ChatApiClient.cs
@@ -30,15 +30,19 @@ public class ChatApiClient(HttpClient http, ILoggerFactory loggerFactory) : ICha
     public async IAsyncEnumerable<ChatResponse> SendMessageAsync(ChatRequest request)
     {
         _logger.LogInformation("API 요청 시뮬레이션: {Message}", request.Messages.LastOrDefault()?.Message ?? "빈 메시지");
+        
+        var httpResponse = await _http.PostAsJsonAsync("/api/chat/complete", request);
+        httpResponse.EnsureSuccessStatusCode();
 
-        // 하드코딩된 응답 반환
-        var responses = loremipsum.Split([ " ", "\r", "\n" ], StringSplitOptions.RemoveEmptyEntries)
-                                  .Select(message => new ChatResponse { Message = message.Trim() });
+        var responses = await httpResponse.Content.ReadFromJsonAsync<List<ChatResponse>>();
+        if (responses is null || responses.Count == 0)
+        {
+            yield break;
+        }
 
         // 응답 메시지 전송
         foreach (var response in responses)
         {
-            await Task.Delay(100);
             yield return response;
         }
 

--- a/src/InterviewAssistant.Web/Components/Pages/Home.razor
+++ b/src/InterviewAssistant.Web/Components/Pages/Home.razor
@@ -141,16 +141,16 @@
     {
         if (e.Key == "Enter" && !e.ShiftKey)
         {
-        // 텍스트 영역의 실제 값을 JavaScript를 통해 가져옵니다
-        var actualValue = await JSRuntime.InvokeAsync<string>("getTextAreaValue", "messageInput");
-        
-        // 실제 값이 비어있지 않은 경우에만 메시지를 보냅니다
-        if (!string.IsNullOrWhiteSpace(actualValue))
-        {
-            // 실제 값으로 userInput을 갱신합니다
-            userInput = actualValue;
-            await SendMessage();
-        }
+            // 텍스트 영역의 실제 값을 JavaScript를 통해 가져옵니다
+            var actualValue = await JSRuntime.InvokeAsync<string>("getTextAreaValue", "messageInput");
+
+            // 실제 값이 비어있지 않은 경우에만 메시지를 보냅니다
+            if (!string.IsNullOrWhiteSpace(actualValue))
+            {
+                // 실제 값으로 userInput을 갱신합니다
+                userInput = actualValue;
+                await SendMessage();
+            }
         }
     }
 
@@ -162,30 +162,32 @@
 
         var userMessage = new ChatMessage { Role = MessageRoleType.User, Message = userInput };
         messages.Add(userMessage);
-        
+
         var currentInput = userInput;
         userInput = string.Empty;
 
         await ScrollToBottom();
-        
+
         try
         {
             isLoading = true;
             StateHasChanged();
-            
+
             // ChatService를 통해 응답 가져오기
             var responses = ChatService.SendMessageAsync(currentInput);
 
             var assistantMessage = new ChatMessage { Role = MessageRoleType.Assistant, Message = string.Empty };
             messages.Add(assistantMessage);
 
-            // 2초 동안 버퍼링 (로딩 인디케이터 유지)
-            await Task.Delay(2000);
-            isLoading = false;
-            StateHasChanged();
-
+            bool first = true;
             await foreach (var response in responses)
-            {
+            {    if (first)
+                {
+                    isLoading = false;
+                    first = false;
+                    StateHasChanged(); // 첫 문자 등자 등장하면 로딩 끄고 UI 갱신
+                }
+                
                 // 점진적으로 메시지를 추가하면서 렌더링
                 assistantMessage.Message += response.Message + " ";
                 await ScrollToBottom();
@@ -198,7 +200,6 @@
         }
         finally
         {
-            isLoading = false;
             StateHasChanged();
             await ScrollToBottom();
             await JSRuntime.InvokeVoidAsync("resetTextAreaHeight", "messageInput");

--- a/test/InterviewAssistant.Web.Tests/Clients/ChatApiClientTests.cs
+++ b/test/InterviewAssistant.Web.Tests/Clients/ChatApiClientTests.cs
@@ -1,14 +1,13 @@
-using InterviewAssistant.Common.Models;
-using InterviewAssistant.Web.Clients;
-
-using Microsoft.Extensions.Logging;
-
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text;
 using System.Text.Json;
 
+using InterviewAssistant.Common.Models;
+using InterviewAssistant.Web.Clients;
+
+using Microsoft.Extensions.Logging;
 
 namespace InterviewAssistant.Web.Tests.Clients;
 

--- a/test/InterviewAssistant.Web.Tests/Clients/FakeHttpMessageHandler.cs
+++ b/test/InterviewAssistant.Web.Tests/Clients/FakeHttpMessageHandler.cs
@@ -1,0 +1,22 @@
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace InterviewAssistant.Web.Tests.Clients
+{
+  public class FakeHttpMessageHandler : HttpMessageHandler
+  {
+    private readonly HttpResponseMessage _fakeResponse;
+
+    public FakeHttpMessageHandler(HttpResponseMessage response)
+    {
+      _fakeResponse = response;
+    }
+
+    protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+      return Task.FromResult(_fakeResponse);
+    }
+  }
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> ex) #38 


## 📝 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요.(이미지 첨부 가능)
- ChatApiClient.cs에서 백엔드 API 연결 성공. GPT 응답 연동 완료
- Home.razor 파일에서 하드코딩되어서 초기 몇초만 동작하던 로딩 애니메이션을 실제 첫 메세지가 등장하기 전까지 재생되도록 수정

### 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/7de48c9e-c0d3-449b-b852-15df7747c691)

## ⏰ 현재 버그
채팅이 스페이스바로 끊겨서 출력되는 버그가 있습니다.

## ✏ Git Close
> close #38 
