### PR TITLE
chore: Markdig 패키지 및 마크다운 인라인 렌더링 함수 추가

### DIFF
--- a/src/InterviewAssistant.Web/Components/Pages/Home.razor
+++ b/src/InterviewAssistant.Web/Components/Pages/Home.razor
@@ -1,12 +1,13 @@
 ﻿@page "/"
+@using System.Text.RegularExpressions
 @using InterviewAssistant.Common.Models
 @using InterviewAssistant.Web.Services
+@using Markdig
+@using Microsoft.AspNetCore.Components.Web
 @inject IChatService ChatService
 @inject IJSRuntime JSRuntime
 @inject ILogger<Home> Logger
 @rendermode InteractiveServer
-@using Markdig
-@using System.Text.RegularExpressions
 
 <PageTitle>면접 코치 - InterviewAssistant</PageTitle>
 
@@ -59,7 +60,7 @@
             {
                 <div class="message @(message.Role == MessageRoleType.User ? "user-message" : "bot-message")">
                     <div class="message-content">
-                        @((MarkupString)ConvertMarkdownInline(message.Message))
+                        @((MarkupString)Markdown.ToHtml(message.Message).Trim())
                     </div>
                 </div>
             }
@@ -150,7 +151,7 @@
             if (!string.IsNullOrWhiteSpace(actualValue))
             {
                 // 실제 값으로 userInput을 갱신합니다
-                userInput = actualValue;
+                userInput = actualValue.TrimEnd('\n', '\r');
                 await SendMessage();
             }
         }
@@ -183,7 +184,8 @@
 
             bool first = true;
             await foreach (var response in responses)
-            {    if (first)
+            {    
+                if (first)
                 {
                     isLoading = false;
                     first = false;
@@ -225,10 +227,5 @@
             await JSRuntime.InvokeVoidAsync("setupTextAreaResize", "messageInput");
         }
         await base.OnAfterRenderAsync(firstRender);
-    }
-    private string ConvertMarkdownInline(string? markdown)
-    {
-        var html = Markdown.ToHtml(markdown?.Trim() ?? "");
-        return System.Text.RegularExpressions.Regex.Replace(html, @"^<p>(.*?)</p>\r?\n?$", "<span>$1</span>", System.Text.RegularExpressions.RegexOptions.Singleline);
     }
 }

--- a/src/InterviewAssistant.Web/Components/Pages/Home.razor
+++ b/src/InterviewAssistant.Web/Components/Pages/Home.razor
@@ -1,9 +1,7 @@
 ﻿@page "/"
-@using System.Text.RegularExpressions
 @using InterviewAssistant.Common.Models
 @using InterviewAssistant.Web.Services
 @using Markdig
-@using Microsoft.AspNetCore.Components.Web
 @inject IChatService ChatService
 @inject IJSRuntime JSRuntime
 @inject ILogger<Home> Logger

--- a/src/InterviewAssistant.Web/Components/Pages/Home.razor
+++ b/src/InterviewAssistant.Web/Components/Pages/Home.razor
@@ -5,6 +5,8 @@
 @inject IJSRuntime JSRuntime
 @inject ILogger<Home> Logger
 @rendermode InteractiveServer
+@using Markdig
+@using System.Text.RegularExpressions
 
 <PageTitle>면접 코치 - InterviewAssistant</PageTitle>
 
@@ -57,7 +59,7 @@
             {
                 <div class="message @(message.Role == MessageRoleType.User ? "user-message" : "bot-message")">
                     <div class="message-content">
-                        @((MarkupString)message.Message)
+                        @((MarkupString)ConvertMarkdownInline(message.Message))
                     </div>
                 </div>
             }
@@ -223,5 +225,10 @@
             await JSRuntime.InvokeVoidAsync("setupTextAreaResize", "messageInput");
         }
         await base.OnAfterRenderAsync(firstRender);
+    }
+    private string ConvertMarkdownInline(string? markdown)
+    {
+        var html = Markdown.ToHtml(markdown?.Trim() ?? "");
+        return System.Text.RegularExpressions.Regex.Replace(html, @"^<p>(.*?)</p>\r?\n?$", "<span>$1</span>", System.Text.RegularExpressions.RegexOptions.Singleline);
     }
 }

--- a/src/InterviewAssistant.Web/InterviewAssistant.Web.csproj
+++ b/src/InterviewAssistant.Web/InterviewAssistant.Web.csproj
@@ -11,4 +11,8 @@
     <ProjectReference Include="..\InterviewAssistant.Common\InterviewAssistant.Common.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Markdig" Version="0.40.0" />
+  </ItemGroup>
+
 </Project>

--- a/src/InterviewAssistant.Web/InterviewAssistant.Web.csproj
+++ b/src/InterviewAssistant.Web/InterviewAssistant.Web.csproj
@@ -7,12 +7,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\InterviewAssistant.ServiceDefaults\InterviewAssistant.ServiceDefaults.csproj" />
-    <ProjectReference Include="..\InterviewAssistant.Common\InterviewAssistant.Common.csproj" />
+    <PackageReference Include="Markdig" Version="0.*" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Markdig" Version="0.40.0" />
+    <ProjectReference Include="..\InterviewAssistant.ServiceDefaults\InterviewAssistant.ServiceDefaults.csproj" />
+    <ProjectReference Include="..\InterviewAssistant.Common\InterviewAssistant.Common.csproj" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> #44 


## 📝 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요.(이미지 첨부 가능)
- Markdig 패키지를 추가하여 마크다운 렌더링 기능을 지원함
- 마크다운을 인라인 HTML(<span>)로 변환하는 유틸리티 함수 추가

### 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/4ec79d48-3597-4b34-a4e2-4855b8b4f5e2)



## 💬 리뷰 요구사항(선택)

> 참고사항으로 주신 내용에서는 ToHtml함수로 처리되었는데 실제로 해보니 p가 마지막에 공백이 생기는 문제가 생겨서 span으로 바꾸어 진행하였습니다.  <span>으로 진행했을 때 문제가 될까요?


## ⏰ 현재 버그


## ✏ Git Close
> close #44 
