### PR TITLE
feat: 대화 히스토리를 ChatService로 이동하고, 로그 관리

### DIFF
--- a/src/InterviewAssistant.Common/Models/ChatHistory.cs
+++ b/src/InterviewAssistant.Common/Models/ChatHistory.cs
@@ -1,6 +1,0 @@
-namespace InterviewAssistant.Common.Models;
-
-public class ChatHistory
-{
-    public List<ChatMessage> Messages { get; set; } = new();
-}

--- a/src/InterviewAssistant.Common/Models/ChatHistory.cs
+++ b/src/InterviewAssistant.Common/Models/ChatHistory.cs
@@ -1,0 +1,6 @@
+namespace InterviewAssistant.Common.Models;
+
+public class ChatHistory
+{
+    public List<ChatMessage> Messages { get; set; } = new();
+}

--- a/src/InterviewAssistant.Web/Components/Pages/Home.razor
+++ b/src/InterviewAssistant.Web/Components/Pages/Home.razor
@@ -161,10 +161,8 @@
         if (string.IsNullOrWhiteSpace(userInput) || isLoading)
             return;
 
-        messages.Add(new ChatMessage { 
-            Role = MessageRoleType.User, 
-            Message = userInput 
-        });
+        var userMessage = new ChatMessage { Role = MessageRoleType.User, Message = userInput };
+        messages.Add(userMessage);
 
         userInput = string.Empty;
 

--- a/src/InterviewAssistant.Web/Components/Pages/Home.razor
+++ b/src/InterviewAssistant.Web/Components/Pages/Home.razor
@@ -161,10 +161,11 @@
         if (string.IsNullOrWhiteSpace(userInput) || isLoading)
             return;
 
-        var userMessage = new ChatMessage { Role = MessageRoleType.User, Message = userInput };
-        messages.Add(userMessage);
+        messages.Add(new ChatMessage { 
+            Role = MessageRoleType.User, 
+            Message = userInput 
+        });
 
-        var currentInput = userInput;
         userInput = string.Empty;
 
         await ScrollToBottom();
@@ -175,7 +176,7 @@
             StateHasChanged();
 
             // ChatService를 통해 응답 가져오기
-            var responses = ChatService.SendMessageAsync(currentInput);
+            var responses = ChatService.SendMessageAsync(messages);
 
             var assistantMessage = new ChatMessage { Role = MessageRoleType.Assistant, Message = string.Empty };
             messages.Add(assistantMessage);

--- a/src/InterviewAssistant.Web/Services/ChatService.cs
+++ b/src/InterviewAssistant.Web/Services/ChatService.cs
@@ -24,7 +24,6 @@ public class ChatService(IChatApiClient client, ILoggerFactory loggerFactory) : 
     private readonly IChatApiClient _client = client ?? throw new ArgumentNullException(nameof(client));
     private readonly ILogger<ChatService> _logger = (loggerFactory ?? throw new ArgumentNullException(nameof(loggerFactory)))
                                                     .CreateLogger<ChatService>();
-    private readonly ChatHistory _chatHistory = new(); // 대화 히스토리 객체
     
     /// <inheritdoc/>
     public async IAsyncEnumerable<ChatResponse> SendMessageAsync(string message)
@@ -37,48 +36,24 @@ public class ChatService(IChatApiClient client, ILoggerFactory loggerFactory) : 
         
         _logger.LogInformation("메시지 처리 시작: {Message}", message);
 
-        // 사용자 메시지를 대화 히스토리에 추가
-        _chatHistory.Messages.Add(new ChatMessage 
-        {
-            Role = MessageRoleType.User, 
-            Message = message.Trim()
-        });
-
-        // responses를 받을 때 임시로 메세지를 누적할 변수 생성
-        string accumulatedBotMessage = string.Empty;
+        // 현재는 메세지 트림만 처리한다
+        string processedMessage = message.Trim();
+                    
         // API 요청 생성 및 전송 (현재는 하드코딩된 응답을 반환하는 ChatApiClient 사용)
         var request = new ChatRequest
-        {
-            Messages = _chatHistory.Messages // 전체 대화 히스토리를 포함해서 요청
+        { 
+            Messages =
+            [
+                new ChatMessage { Role = MessageRoleType.User, Message = processedMessage }
+            ]
         };
         var responses = _client.SendMessageAsync(request);
         
         await foreach (var response in responses)
         {
-            accumulatedBotMessage += response.Message; // 스트림으로 들어오는 대화를 누적 
             yield return response;
         }
 
-        // 스트리밍이 끝난 뒤, 하나의 메시지로 Assistant 히스토리에 추가
-        if (!string.IsNullOrWhiteSpace(accumulatedBotMessage))
-        {
-            var botMessage = new ChatMessage { Role = MessageRoleType.Assistant, Message = accumulatedBotMessage.Trim() };
-            _chatHistory.Messages.Add(botMessage);
-
-            LogChatHistory(); // 히스토리 출력
-        }
         _logger.LogInformation("메시지 처리 완료");
-    }
-
-    /// <summary>
-    /// 대화 히스토리를 로그로 출력합니다.
-    /// </summary>
-    private void LogChatHistory()
-    {
-        _logger.LogInformation("현재 대화 히스토리:");
-        foreach (var message in _chatHistory.Messages)
-        {
-            _logger.LogInformation("[{Role}] {Message}", message.Role, message.Message);
-        }
     }
 }

--- a/src/InterviewAssistant.Web/Services/ChatService.cs
+++ b/src/InterviewAssistant.Web/Services/ChatService.cs
@@ -13,7 +13,7 @@ public interface IChatService
     /// </summary>
     /// <param name="messages">사용자 메시지</param>
     /// <returns>처리된 챗봇 응답</returns>
-    IAsyncEnumerable<ChatResponse> SendMessageAsync(List<ChatMessage> messages);
+    IAsyncEnumerable<ChatResponse> SendMessageAsync(IEnumerable<ChatMessage> messages);
 }
 
 /// <summary>
@@ -26,19 +26,19 @@ public class ChatService(IChatApiClient client, ILoggerFactory loggerFactory) : 
                                                     .CreateLogger<ChatService>();
     
     /// <inheritdoc/>
-    public async IAsyncEnumerable<ChatResponse> SendMessageAsync(List<ChatMessage> messages)
+    public async IAsyncEnumerable<ChatResponse> SendMessageAsync(IEnumerable<ChatMessage> messages)
     {
-        if (messages == null || messages.Count == 0)
+        if (messages == null || !messages.Any())
         {
             _logger.LogWarning("빈 메시지 목록이 전송되었습니다.");
             yield break;
         }
         
-        _logger.LogInformation("메시지 목록 처리 시작: {Count}개", messages.Count);
+        _logger.LogInformation("메시지 목록 처리 시작: {Count}개", messages.Count());
 
         // 메시지 목록 정리 (필요 시 트림 등 추가 가능)
         var processedMessages = messages
-            .Where(m => !string.IsNullOrWhiteSpace(m.Message))
+            .Where(m => string.IsNullOrWhiteSpace(m.Message.Trim()) == false)
             .Select(m => new ChatMessage
             {
                 Role = m.Role,

--- a/src/InterviewAssistant.Web/Services/ChatService.cs
+++ b/src/InterviewAssistant.Web/Services/ChatService.cs
@@ -24,6 +24,7 @@ public class ChatService(IChatApiClient client, ILoggerFactory loggerFactory) : 
     private readonly IChatApiClient _client = client ?? throw new ArgumentNullException(nameof(client));
     private readonly ILogger<ChatService> _logger = (loggerFactory ?? throw new ArgumentNullException(nameof(loggerFactory)))
                                                     .CreateLogger<ChatService>();
+    private readonly ChatHistory _chatHistory = new(); // 대화 히스토리 객체
     
     /// <inheritdoc/>
     public async IAsyncEnumerable<ChatResponse> SendMessageAsync(string message)
@@ -36,24 +37,48 @@ public class ChatService(IChatApiClient client, ILoggerFactory loggerFactory) : 
         
         _logger.LogInformation("메시지 처리 시작: {Message}", message);
 
-        // 현재는 메세지 트림만 처리한다
-        string processedMessage = message.Trim();
-                    
+        // 사용자 메시지를 대화 히스토리에 추가
+        _chatHistory.Messages.Add(new ChatMessage 
+        {
+            Role = MessageRoleType.User, 
+            Message = message.Trim()
+        });
+
+        // responses를 받을 때 임시로 메세지를 누적할 변수 생성
+        string accumulatedBotMessage = string.Empty;
         // API 요청 생성 및 전송 (현재는 하드코딩된 응답을 반환하는 ChatApiClient 사용)
         var request = new ChatRequest
-        { 
-            Messages =
-            [
-                new ChatMessage { Role = MessageRoleType.User, Message = processedMessage }
-            ]
+        {
+            Messages = _chatHistory.Messages // 전체 대화 히스토리를 포함해서 요청
         };
         var responses = _client.SendMessageAsync(request);
         
         await foreach (var response in responses)
         {
+            accumulatedBotMessage += response.Message; // 스트림으로 들어오는 대화를 누적 
             yield return response;
         }
 
+        // 스트리밍이 끝난 뒤, 하나의 메시지로 Assistant 히스토리에 추가
+        if (!string.IsNullOrWhiteSpace(accumulatedBotMessage))
+        {
+            var botMessage = new ChatMessage { Role = MessageRoleType.Assistant, Message = accumulatedBotMessage.Trim() };
+            _chatHistory.Messages.Add(botMessage);
+
+            LogChatHistory(); // 히스토리 출력
+        }
         _logger.LogInformation("메시지 처리 완료");
+    }
+
+    /// <summary>
+    /// 대화 히스토리를 로그로 출력합니다.
+    /// </summary>
+    private void LogChatHistory()
+    {
+        _logger.LogInformation("현재 대화 히스토리:");
+        foreach (var message in _chatHistory.Messages)
+        {
+            _logger.LogInformation("[{Role}] {Message}", message.Role, message.Message);
+        }
     }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> #47 


## 📝 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요.(이미지 첨부 가능)
- 이전 대화를 히스토리 객체에 저장하고 관리합니다.
- ChatService.cs에서 대화 히스토리 관리할 수 있도록 ChatHistory.cs 추가하였습니다.

### 스크린샷 (선택)
기존 응답
![a는 몇](https://github.com/user-attachments/assets/8bc8ce78-16ca-4d03-b146-b3ac334e3e55)
수정된 코드에서의 응답
![a를 기억중](https://github.com/user-attachments/assets/94aa1514-4163-4a8d-b6dd-e00bc18a96b3)

## 💬 리뷰 요구사항(선택)

> ChatService내에서 끝낼 수 있는 작업을 이후에 확장될걸 고려해서 ChatHistory를 생성했습니다.
고려했던 확장 내용은 질문 유형구분, 피드백정도로 생각 중입니다. 혹시 확장할 필요가 없을까요?

## ⏰ 현재 버그


## ✏ Git Close
> close #47 
