### PR TITLE
chore: 서버 응답 플래그 생성 및 사용자 전송 제한

### DIFF
--- a/src/InterviewAssistant.Web/Components/Pages/Home.razor
+++ b/src/InterviewAssistant.Web/Components/Pages/Home.razor
@@ -2,6 +2,7 @@
 @using InterviewAssistant.Common.Models
 @using InterviewAssistant.Web.Services
 @using Markdig
+@using Microsoft.JSInterop
 @inject IChatService ChatService
 @inject IJSRuntime JSRuntime
 @inject ILogger<Home> Logger
@@ -88,10 +89,16 @@
                 placeholder="메시지를 입력하세요." 
                 rows="1"
                 disabled="@(isLoading || !isLinkShared)"></textarea>
-            <button class="send-btn" @onclick="SendMessage" disabled="@(string.IsNullOrWhiteSpace(userInput) || isLoading)">
+            <button class="send-btn" @onclick="SendMessage" disabled="@(string.IsNullOrWhiteSpace(userInput) || isLoading || !isServerOutputEnded)">
                 <span class="send-icon">↵</span>
             </button>
         </div>
+        @if (!isServerOutputEnded)
+        {
+            <div class="response-status">
+                <small>서버 응답 출력 중... 출력이 완료될 때까지 기다려주세요.</small>
+            </div>
+        }
     </div>
 </div>
 
@@ -101,7 +108,7 @@
     private bool isLoading = false;
     // 링크 공유 여부
     private bool isLinkShared = false;
-
+    private bool isServerOutputEnded = true;
     // 모달 관련 변수
     private bool showModal = false;
     private string resumeUrl = string.Empty;
@@ -158,7 +165,7 @@
     // 메시지 전송 - 서비스 사용
     private async Task SendMessage()
     {
-        if (string.IsNullOrWhiteSpace(userInput) || isLoading)
+        if (string.IsNullOrWhiteSpace(userInput) || isLoading || !isServerOutputEnded)
             return;
 
         var userMessage = new ChatMessage { Role = MessageRoleType.User, Message = userInput };
@@ -171,6 +178,7 @@
         try
         {
             isLoading = true;
+            isServerOutputEnded = false; // 서버 응답이 시작됨을 표시
             StateHasChanged();
 
             // ChatService를 통해 응답 가져오기
@@ -186,7 +194,7 @@
                 {
                     isLoading = false;
                     first = false;
-                    StateHasChanged(); // 첫 문자 등자 등장하면 로딩 끄고 UI 갱신
+                    StateHasChanged(); // 첫 문자 등장하면 로딩 끄고 UI 갱신
                 }
                 
                 // 점진적으로 메시지를 추가하면서 렌더링
@@ -201,6 +209,7 @@
         }
         finally
         {
+            isServerOutputEnded = true; // 서버 응답이 끝났음을 표시
             StateHasChanged();
             await ScrollToBottom();
             await JSRuntime.InvokeVoidAsync("resetTextAreaHeight", "messageInput");

--- a/src/InterviewAssistant.Web/Components/Pages/Home.razor
+++ b/src/InterviewAssistant.Web/Components/Pages/Home.razor
@@ -89,7 +89,7 @@
                 placeholder="메시지를 입력하세요." 
                 rows="1"
                 disabled="@(isLoading || !isLinkShared)"></textarea>
-            <button class="send-btn" @onclick="SendMessage" disabled="@(string.IsNullOrWhiteSpace(userInput) || isLoading || !isServerOutputEnded)">
+            <button class="send-btn" @onclick="SendMessage" disabled="@IsReadyToSendMessage()">
                 <span class="send-icon">↵</span>
             </button>
         </div>
@@ -165,8 +165,10 @@
     // 메시지 전송 - 서비스 사용
     private async Task SendMessage()
     {
-        if (string.IsNullOrWhiteSpace(userInput) || isLoading || !isServerOutputEnded)
+        if (IsReadyToSendMessage())
+        {
             return;
+        }
 
         var userMessage = new ChatMessage { Role = MessageRoleType.User, Message = userInput };
         messages.Add(userMessage);
@@ -215,6 +217,11 @@
             await JSRuntime.InvokeVoidAsync("resetTextAreaHeight", "messageInput");
             await JSRuntime.InvokeVoidAsync("focusTextArea", "messageInput");
         }
+    }
+
+    private bool IsReadyToSendMessage()
+    {
+        return string.IsNullOrWhiteSpace(userInput) || isLoading || !isServerOutputEnded;
     }
 
     // 채팅창 스크롤을 항상 최하단으로


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> ex) #54 


## 📝 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요.(이미지 첨부 가능)
- isServerOutputEnded 플래그 생성하여 서버 출력 동안 대기 메세지를 보여줍니다
- 사용자 입력은 가능하나 enter키 사용 제한, 전송 버튼 클릭 제한하였습니다.

### 스크린샷 (선택)
![스크린샷(15)](https://github.com/user-attachments/assets/495f28ba-0616-48d4-a8dc-6d4837936df1)
![스크린샷(16)](https://github.com/user-attachments/assets/ad3cd417-62da-4af3-983d-ac409751567f)


## 💬 리뷰 요구사항(선택)

> 


## ⏰ 현재 버그


## ✏ Git Close
> close #54 
