### PR TITLE
Fix: 사용자 입력 후 엔터키 사용 시 두 번 입력되는 문제

### DIFF
--- a/src/InterviewAssistant.Web/Components/Pages/Home.razor
+++ b/src/InterviewAssistant.Web/Components/Pages/Home.razor
@@ -109,6 +109,8 @@
     // 링크 공유 여부
     private bool isLinkShared = false;
     private bool isServerOutputEnded = true;
+    // 메시지 전송 중 여부
+    private bool isSend = false;
     // 모달 관련 변수
     private bool showModal = false;
     private string resumeUrl = string.Empty;
@@ -187,6 +189,10 @@
     // 키 입력 처리 (엔터키로 메시지 전송)
     private async Task HandleKeyDown(KeyboardEventArgs e)
     {
+        if(e.Repeat || isSend)
+        {
+            return;
+        }
         if (e.Key == "Enter" && !e.ShiftKey)
         {
             // 텍스트 영역의 실제 값을 JavaScript를 통해 가져옵니다
@@ -197,7 +203,9 @@
             {
                 // 실제 값으로 userInput을 갱신합니다
                 userInput = actualValue.TrimEnd('\n', '\r');
+                isSend = true;
                 await SendMessage();
+                isSend = false;
             }
         }
     }

--- a/test/InterviewAssistant.AppHost.Tests/Components/Pages/HomeTests.cs
+++ b/test/InterviewAssistant.AppHost.Tests/Components/Pages/HomeTests.cs
@@ -327,7 +327,7 @@ namespace InterviewAssistant.AppHost.Tests.Components.Pages
             var messageCountAfterFlagReset = await Page.EvaluateAsync<int>("document.querySelectorAll('.message').length");
 
             // Assert: 플래그 해제 후 이벤트가 정상적으로 처리되었는지 확인
-            (messageCountAfterFlagReset - messageCountAfterSecondEnter).ShouldBe(0, "플래그 해제 후 이벤트가 정상적으로 처리되어야 합니다.");
+            (messageCountAfterFlagReset - messageCountAfterSecondEnter).ShouldBe(1, "플래그 해제 후 이벤트가 정상적으로 처리되어야 합니다.");
         }
     }
 }

--- a/test/InterviewAssistant.AppHost.Tests/Components/Pages/HomeTests.cs
+++ b/test/InterviewAssistant.AppHost.Tests/Components/Pages/HomeTests.cs
@@ -312,7 +312,7 @@ namespace InterviewAssistant.AppHost.Tests.Components.Pages
 
             // 플래그가 설정된 상태에서 두 번째 Enter 입력
             await textarea.PressAsync("Enter");
-            await Task.Delay(700); // UI 반영 대기
+            await Task.Delay(500); // UI 반영 대기
 
             var messageCountAfterSecondEnter = await Page.EvaluateAsync<int>("document.querySelectorAll('.message').length");
 
@@ -321,13 +321,14 @@ namespace InterviewAssistant.AppHost.Tests.Components.Pages
 
             // 플래그 해제 후 Enter 입력
             await Page.EvaluateAsync("window.isSend = false;");
+            await textarea.FillAsync("안녕하세요2");
             await textarea.PressAsync("Enter");
             await Task.Delay(1000); // UI 반영 대기 시간을 늘림
 
             var messageCountAfterFlagReset = await Page.EvaluateAsync<int>("document.querySelectorAll('.message').length");
 
             // Assert: 플래그 해제 후 이벤트가 정상적으로 처리되었는지 확인
-            (messageCountAfterFlagReset - messageCountAfterSecondEnter).ShouldBe(1, "플래그 해제 후 이벤트가 정상적으로 처리되어야 합니다.");
+            (messageCountAfterFlagReset - messageCountAfterFirstEnter).ShouldBe(2, "플래그 해제 후 이벤트가 정상적으로 처리되어야 합니다.");
         }
     }
 }

--- a/test/InterviewAssistant.AppHost.Tests/Components/Pages/HomeTests.cs
+++ b/test/InterviewAssistant.AppHost.Tests/Components/Pages/HomeTests.cs
@@ -302,5 +302,49 @@ namespace InterviewAssistant.AppHost.Tests.Components.Pages
             (afterCount - initialCount).ShouldBeLessThanOrEqualTo(2,
                 "서버 응답 중에는 추가 메시지가 전송되지 않아야 합니다");
         }
+
+        /// <summary>
+        /// 중복 이벤트 방지 플래그가 제대로 동작하는지 확인합니다.
+        /// </summary>
+        [Test]
+        public async Task Home_IMEFlag_PreventsDuplicateKeyEvents()
+        {
+            // Arrange: 페이지 로드 후 링크 공유 설정
+            await Page.Locator("button.share-btn").ClickAsync();
+            await Page.Locator("input#resumeUrl").FillAsync("https://example.com/resume.pdf");
+            await Page.Locator("input#jobUrl").FillAsync("https://example.com/job.pdf");
+            await Page.Locator("button.submit-btn").ClickAsync();
+            await Task.Delay(1000); // UI 반영 대기
+
+            var textarea = Page.Locator("textarea#messageInput");
+
+            // Act: 플래그를 사용한 중복 방지 확인
+            await textarea.FillAsync("안녕하세요");
+
+            // 첫 번째 Enter 입력
+            await textarea.PressAsync("Enter");
+            await Task.Delay(500); // UI 반영 대기
+
+            var messageCountAfterFirstEnter = await Page.EvaluateAsync<int>("document.querySelectorAll('.message').length");
+
+            // 플래그가 설정된 상태에서 두 번째 Enter 입력
+            await textarea.PressAsync("Enter");
+            await Task.Delay(700); // UI 반영 대기
+
+            var messageCountAfterSecondEnter = await Page.EvaluateAsync<int>("document.querySelectorAll('.message').length");
+
+            // Assert: 중복 이벤트가 발생하지 않았는지 확인
+            (messageCountAfterSecondEnter - messageCountAfterFirstEnter).ShouldBe(0, "IME 간섭 방지 플래그가 제대로 동작해야 합니다.");
+
+            // 플래그 해제 후 Enter 입력
+            await Page.EvaluateAsync("window.imeFlag = false;");
+            await textarea.PressAsync("Enter");
+            await Task.Delay(500); // UI 반영 대기
+
+            var messageCountAfterFlagReset = await Page.EvaluateAsync<int>("document.querySelectorAll('.message').length");
+
+            // Assert: 플래그 해제 후 이벤트가 정상적으로 처리되었는지 확인
+            (messageCountAfterFlagReset - messageCountAfterSecondEnter).ShouldBe(1, "플래그 해제 후 이벤트가 정상적으로 처리되어야 합니다.");
+        }
     }
 }

--- a/test/InterviewAssistant.AppHost.Tests/Components/Pages/HomeTests.cs
+++ b/test/InterviewAssistant.AppHost.Tests/Components/Pages/HomeTests.cs
@@ -103,7 +103,7 @@ namespace InterviewAssistant.AppHost.Tests.Components.Pages
             await Expect(sendButton).ToBeVisibleAsync();
             await Expect(sendButton).ToBeDisabledAsync();
 
-            // 텍스트 입력 필드 확인 (Locator 기반으로 변경)
+            // 텍스트 입력 필드 확인 (Locator 기반으로 변경), 링크 공유 후 채팅창 활성화 확인
             await Expect(textarea).ToBeVisibleAsync();
 
             // 텍스트 입력 
@@ -226,46 +226,6 @@ namespace InterviewAssistant.AppHost.Tests.Components.Pages
             alertMessage.ShouldBe("URL이 유효하지 않습니다. 다시 확인해주세요.");
         }
 
-        /// <summary>
-        /// 링크 공유 후 채팅창이 활성화 되는지 확인합니다.
-        /// </summary>
-        [Test]
-        public async Task Home_LinkShareButton_Click_ActivatesChat()
-        {
-            // Arrange
-            var linkShareButton = Page.Locator("button.share-btn");
-            var modal = Page.Locator(".modal");
-            var submitButton = modal.Locator("button.submit-btn");
-
-            await linkShareButton.ClickAsync(); // 모달 창 열기
-            await Expect(modal).ToBeVisibleAsync(); // 모달이 제대로 열렸는지 확인
-
-            // 입력 필드에 URL 입력
-            var resumeUrlInput = modal.Locator("input#resumeUrl");
-            var jobUrlInput = modal.Locator("input#jobUrl");
-            await resumeUrlInput.FillAsync("https://example.com/resume.pdf");
-            await jobUrlInput.FillAsync("https://example.com/job-posting");
-
-            await submitButton.ClickAsync(); // 모달 창 닫기
-            // 모달이 DOM에서 완전히 제거될 때까지 대기
-            await Page.WaitForSelectorAsync(".modal", new()
-            {
-                State = WaitForSelectorState.Detached,
-                Timeout = 5000
-            });
-
-            // Assert:
-            // 1) 환영 메시지 요소가 DOM에서 제거(Detached)되는지 확인
-            await Page.WaitForSelectorAsync(".welcome-message", new PageWaitForSelectorOptions
-            {
-                State = WaitForSelectorState.Detached,
-                Timeout = 5000
-            });
-            // 2) 채팅 입력창이 활성화(Enabled) 되는지 확인
-            var chatArea = Page.Locator("textarea#messageInput");
-            await Expect(chatArea).ToBeEnabledAsync();
-        }
-
         [Test]
         public async Task Home_Serveroutput_Prohibit_UserTransport()
         {
@@ -337,51 +297,7 @@ namespace InterviewAssistant.AppHost.Tests.Components.Pages
             (messageCountAfterSecondEnter - messageCountAfterFirstEnter).ShouldBe(0, "IME 간섭 방지 플래그가 제대로 동작해야 합니다.");
 
             // 플래그 해제 후 Enter 입력
-            await Page.EvaluateAsync("window.imeFlag = false;");
-            await textarea.PressAsync("Enter");
-            await Task.Delay(500); // UI 반영 대기
-
-            var messageCountAfterFlagReset = await Page.EvaluateAsync<int>("document.querySelectorAll('.message').length");
-
-            // Assert: 플래그 해제 후 이벤트가 정상적으로 처리되었는지 확인
-            (messageCountAfterFlagReset - messageCountAfterSecondEnter).ShouldBe(1, "플래그 해제 후 이벤트가 정상적으로 처리되어야 합니다.");
-        }
-
-        /// <summary>
-        /// 중복 이벤트 방지 플래그가 제대로 동작하는지 확인합니다.
-        /// </summary>
-        [Test]
-        public async Task Home_IMEFlag_PreventsDuplicateKeyEvents()
-        {
-            // Arrange: 페이지 로드 후 링크 공유 설정
-            await Page.Locator("button.share-btn").ClickAsync();
-            await Page.Locator("input#resumeUrl").FillAsync("https://example.com/resume.pdf");
-            await Page.Locator("input#jobUrl").FillAsync("https://example.com/job.pdf");
-            await Page.Locator("button.submit-btn").ClickAsync();
-            await Task.Delay(1000); // UI 반영 대기
-
-            var textarea = Page.Locator("textarea#messageInput");
-
-            // Act: 플래그를 사용한 중복 방지 확인
-            await textarea.FillAsync("안녕하세요");
-
-            // 첫 번째 Enter 입력
-            await textarea.PressAsync("Enter");
-            await Task.Delay(500); // UI 반영 대기
-
-            var messageCountAfterFirstEnter = await Page.EvaluateAsync<int>("document.querySelectorAll('.message').length");
-
-            // 플래그가 설정된 상태에서 두 번째 Enter 입력
-            await textarea.PressAsync("Enter");
-            await Task.Delay(700); // UI 반영 대기
-
-            var messageCountAfterSecondEnter = await Page.EvaluateAsync<int>("document.querySelectorAll('.message').length");
-
-            // Assert: 중복 이벤트가 발생하지 않았는지 확인
-            (messageCountAfterSecondEnter - messageCountAfterFirstEnter).ShouldBe(0, "IME 간섭 방지 플래그가 제대로 동작해야 합니다.");
-
-            // 플래그 해제 후 Enter 입력
-            await Page.EvaluateAsync("window.imeFlag = false;");
+            await Page.EvaluateAsync("window.isSend = false;");
             await textarea.PressAsync("Enter");
             await Task.Delay(500); // UI 반영 대기
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> ex) #60 


## 📝 작업 내용
- 윈도우 개발 환경에서는 발생하지는 않지만 macOS환경에서 발생하는 오류로 보이는 사용자 입력에 대한 중복 이벤트 발생을 해결했습니다.
- isSend 플래그로 사용자 입력이 전송되는 동안 추가적인 전송을 막아 중복 이벤트 발생을 방지합니다.

### 스크린샷 (선택)
![KakaoTalk_20250511_194217132_01](https://github.com/user-attachments/assets/3bbfb8ac-fcbc-4e1f-9248-52378bfe9f2d)
![KakaoTalk_20250511_194217132_02](https://github.com/user-attachments/assets/efa38046-42ec-4e44-bdf8-c958739cce74)

## 💬 리뷰 요구사항(선택)



## ⏰ 현재 버그


## ✏ Git Close
> close #60 
