### PR TITLE
Deploy: ci-cd pipeline 내부에서 main으로의 push의 경우, 테스트가 실패할 시 깃액션이 실패하도록 조치

### DIFF
--- a/.github/workflows/azure-dev.yml
+++ b/.github/workflows/azure-dev.yml
@@ -83,6 +83,12 @@ jobs:
           echo "❌ Some tests failed. Deployment will be skipped."
         fi
 
+    - name: ❌ Fail Workflow if Tests Failed on Main Push
+      if: github.event_name == 'push' && github.ref == 'refs/heads/main' && steps.test-status.outputs.tests_passed == 'false'
+      run: |
+        echo "Tests failed on main branch push. Failing the workflow."
+        exit 1
+
     - name: 🔄 Convert Test Results to JUnit Format
       if: github.event_name == 'pull_request'
       run: find ./test-results -name '*.trx' -exec trx2junit {} \;

--- a/.github/workflows/azure-dev.yml
+++ b/.github/workflows/azure-dev.yml
@@ -83,12 +83,6 @@ jobs:
           echo "❌ Some tests failed. Deployment will be skipped."
         fi
 
-    - name: ❌ Fail Workflow if Tests Failed on Main Push
-      if: github.event_name == 'push' && github.ref == 'refs/heads/main' && steps.test-status.outputs.tests_passed == 'false'
-      run: |
-        echo "Tests failed on main branch push. Failing the workflow."
-        exit 1
-
     - name: 🔄 Convert Test Results to JUnit Format
       if: github.event_name == 'pull_request'
       run: find ./test-results -name '*.trx' -exec trx2junit {} \;
@@ -106,6 +100,12 @@ jobs:
       with:
         report_paths: '**/test-results/*.xml'
         github_token: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: ❌ Fail Workflow if Tests Failed on Main Push
+      if: github.event_name == 'push' && github.ref == 'refs/heads/main' && steps.test-status.outputs.tests_passed == 'false'
+      run: |
+        echo "Tests failed on main branch push. Failing the workflow."
+        exit 1
 
     - name: 🚀 Log in with Azure (Federated Credentials)
       if: github.event_name == 'push' && github.ref == 'refs/heads/main' && steps.test-status.outputs.tests_passed == 'true'


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- #70 

## 📝 작업 내용
- ci-cd pipeline 내부에서 main으로의 push의 경우, 테스트가 실패할 시 깃액션이 실패하도록 조치

### 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/a7cd30a6-8342-4c2f-91ec-002aa6b011cc)

## ⏰ 현재 버그
정상 작동함을 fork한 레포에서 테스트 완료했습니다.

## ✏ Git Close
> close #70 
