### PR TITLE
Refactor: 이력서 및 채용공고 저장 시 세션별로 ID를 구분하도록 수정

### DIFF
--- a/src/InterviewAssistant.ApiService/Delegates/PostChatCompletionDelegate.cs
+++ b/src/InterviewAssistant.ApiService/Delegates/PostChatCompletionDelegate.cs
@@ -27,8 +27,8 @@ public static partial class ChatCompletionDelegate
         IInterviewRepository repository)
     {
 
-        ResumeEntry? resumeEntry = await repository.GetResumeByIdAsync(ResumeId);
-        JobDescriptionEntry? jobDescriptionEntry = await repository.GetJobByIdAsync(JobDescriptionId);
+        ResumeEntry? resumeEntry = await repository.GetResumeByIdAsync(req.ResumeId);
+        JobDescriptionEntry? jobDescriptionEntry = await repository.GetJobByIdAsync(req.JobDescriptionId);
 
         if (resumeEntry == null || jobDescriptionEntry == null)
         {

--- a/src/InterviewAssistant.ApiService/Delegates/PostChatInterviewDataDelegate.cs
+++ b/src/InterviewAssistant.ApiService/Delegates/PostChatInterviewDataDelegate.cs
@@ -15,9 +15,6 @@ namespace InterviewAssistant.ApiService.Delegates;
 /// </summary>
 public static partial class ChatCompletionDelegate
 {
-    // 고정 ID 정의
-    private static readonly Guid ResumeId = new Guid("11111111-1111-1111-1111-111111111111");
-    private static readonly Guid JobDescriptionId = new Guid("22222222-2222-2222-2222-222222222222");
 
     /// <summary>
     /// Invokes the chat interview data endpoint.
@@ -36,18 +33,18 @@ public static partial class ChatCompletionDelegate
 
         ResumeEntry resumeEntry = new()
         {
-            Id = ResumeId,
+            Id = req.ResumeId,
             Content = resumeContent
         };
-        await repository.SaveOrUpdateResumeAsync(resumeEntry);
+        await repository.SaveResumeAsync(resumeEntry);
 
         JobDescriptionEntry jobDescriptionEntry = new()
         {
-            Id = JobDescriptionId,
+            Id = req.JobDescriptionId,
             Content = jobDescriptionContent,
-            ResumeEntryId = ResumeId
+            ResumeEntryId = req.ResumeId
         };
-        await repository.SaveOrUpdateJobAsync(jobDescriptionEntry);
+        await repository.SaveJobAsync(jobDescriptionEntry);
 
         await foreach (var text in kernelService.InvokeInterviewAgentAsync(resumeContent, jobDescriptionContent))
         {

--- a/src/InterviewAssistant.ApiService/Repositories/IInterviewRepository.cs
+++ b/src/InterviewAssistant.ApiService/Repositories/IInterviewRepository.cs
@@ -7,6 +7,4 @@ public interface IInterviewRepository
     Task<ResumeEntry?> GetResumeByIdAsync(Guid id);
     Task SaveJobAsync(JobDescriptionEntry entity);
     Task<JobDescriptionEntry?> GetJobByIdAsync(Guid id);
-    Task SaveOrUpdateResumeAsync(ResumeEntry entity);
-    Task SaveOrUpdateJobAsync(JobDescriptionEntry entity);
 }

--- a/src/InterviewAssistant.ApiService/Repositories/InterviewRepository.cs
+++ b/src/InterviewAssistant.ApiService/Repositories/InterviewRepository.cs
@@ -36,33 +36,4 @@ public class InterviewRepository : IInterviewRepository
         return await _db.JobDescriptions.FirstOrDefaultAsync(e => e.Id == id);
     }
 
-    public async Task SaveOrUpdateResumeAsync(ResumeEntry entity)
-    {
-        var existingEntity = await _db.Resumes.FirstOrDefaultAsync(e => e.Id == entity.Id);
-
-        if (existingEntity == null)
-        {
-            await _db.Resumes.AddAsync(entity);
-        }
-        else
-        {
-            _db.Entry(existingEntity).CurrentValues.SetValues(entity);
-        }
-        await _db.SaveChangesAsync();
-    }
-
-    public async Task SaveOrUpdateJobAsync(JobDescriptionEntry entity)
-    {
-        var existingEntity = await _db.JobDescriptions.FirstOrDefaultAsync(e => e.Id == entity.Id);
-
-        if (existingEntity == null)
-        {
-            await _db.JobDescriptions.AddAsync(entity);
-        }
-        else
-        {
-            _db.Entry(existingEntity).CurrentValues.SetValues(entity);
-        }
-        await _db.SaveChangesAsync();
-    }
 }

--- a/src/InterviewAssistant.Common/Models/ChatRequest.cs
+++ b/src/InterviewAssistant.Common/Models/ChatRequest.cs
@@ -4,7 +4,17 @@ namespace InterviewAssistant.Common.Models;
 /// This represents the request entity for the chat service. It contains a list of messages that are exchanged between the user and the assistant.
 /// </summary>
 public class ChatRequest
-{   
+{
+    /// <summary>
+    /// Gets or sets the unique identifier for the resume being referenced in the chat.
+    /// </summary>
+    public Guid ResumeId { get; set; } = Guid.Empty;
+
+    /// <summary>
+    /// Gets or sets the unique identifier for the job description being referenced in the chat.
+    /// </summary>
+    public Guid JobDescriptionId { get; set; } = Guid.Empty;
+
     /// <summary>
     /// Gets or sets the list of messages exchanged between the user and the assistant.
     /// </summary>
@@ -51,7 +61,7 @@ public enum MessageRoleType
     /// Identifies the assistant role.
     /// </summary>
     Assistant,
-    
+
     /// <summary>
     /// Identifies the tool role.
     /// </summary>

--- a/src/InterviewAssistant.Common/Models/InterviewDataRequest.cs
+++ b/src/InterviewAssistant.Common/Models/InterviewDataRequest.cs
@@ -5,6 +5,17 @@ namespace InterviewAssistant.Common.Models;
 /// </summary>
 public class InterviewDataRequest
 {
+
+    /// <summary>
+    /// Gets or sets the unique identifier for the resume being referenced in the chat.
+    /// </summary>
+    public Guid ResumeId { get; set; } = Guid.Empty;
+
+    /// <summary>
+    /// Gets or sets the unique identifier for the job description being referenced in the chat.
+    /// </summary>
+    public Guid JobDescriptionId { get; set; } = Guid.Empty;
+
     /// <summary>
     /// Gets or sets the URL of the resume document.
     /// </summary>

--- a/test/InterviewAssistant.ApiService.Tests/Delegates/PostChatCompletionDelegateTests.cs
+++ b/test/InterviewAssistant.ApiService.Tests/Delegates/PostChatCompletionDelegateTests.cs
@@ -69,6 +69,8 @@ public class ChatCompletionDelegateTests
         // Arrange
         var chatRequest = new ChatRequest
         {
+            ResumeId = _validResumeId,
+            JobDescriptionId = _validJobDescriptionId,
             Messages = new List<ChatMessage>
             {
                 new ChatMessage { Role = MessageRoleType.User, Message = "면접을 시작합니다" }
@@ -102,14 +104,16 @@ public class ChatCompletionDelegateTests
         // Arrange
         var chatRequest = new ChatRequest
         {
+            ResumeId = Guid.NewGuid(), // 유효하지 않은 이력서 ID
+            JobDescriptionId = _validJobDescriptionId,
             Messages = new List<ChatMessage>
             {
                 new ChatMessage { Role = MessageRoleType.User, Message = "면접을 시작합니다" }
             }
         };
 
-        // Setup repository to return null for the resume ID
-        _repository.GetResumeByIdAsync(Arg.Is<Guid>(g => g == _validResumeId)).ReturnsNull();
+        // Setup repository to return null for the invalid resume ID
+        _repository.GetResumeByIdAsync(Arg.Is<Guid>(g => g != _validResumeId)).ReturnsNull();
 
         // Act
         var results = new List<ChatResponse>();
@@ -131,14 +135,16 @@ public class ChatCompletionDelegateTests
         // Arrange
         var chatRequest = new ChatRequest
         {
+            ResumeId = _validResumeId,
+            JobDescriptionId = Guid.NewGuid(), // 유효하지 않은 직무 설명 ID
             Messages = new List<ChatMessage>
             {
                 new ChatMessage { Role = MessageRoleType.User, Message = "면접을 시작합니다" }
             }
         };
 
-        // Setup repository to return null for the job description ID
-        _repository.GetJobByIdAsync(Arg.Is<Guid>(g => g == _validJobDescriptionId)).ReturnsNull();
+        // Setup repository to return null for the invalid job description ID
+        _repository.GetJobByIdAsync(Arg.Is<Guid>(g => g != _validJobDescriptionId)).ReturnsNull();
 
         // Act
         var results = new List<ChatResponse>();
@@ -154,13 +160,14 @@ public class ChatCompletionDelegateTests
         results[0].Message.ShouldBe("이력서 또는 채용공고 데이터가 없습니다.");
     }
 
-
     [Test]
     public async Task PostChatCompletionAsync_WithMultipleResponses_ShouldReturnAllResponses()
     {
         // Arrange
         var chatRequest = new ChatRequest
         {
+            ResumeId = _validResumeId,
+            JobDescriptionId = _validJobDescriptionId,
             Messages = new List<ChatMessage>
             {
                 new ChatMessage { Role = MessageRoleType.User, Message = "면접을 시작합니다" }
@@ -195,5 +202,4 @@ public class ChatCompletionDelegateTests
         results[1].Message.ShouldBe("먼저 자기소개 부탁드립니다.");
         results[2].Message.ShouldBe("이력서를 보니 프론트엔드 개발자 경험이 있으시네요.");
     }
-
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- #69 


## 📝 작업 내용
- [x] 프론트에서 ID를 받아오도록 request 수정
- [x] 이력서 및 채용공고 저장 로직 수정

### 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

## ⏰ 현재 버그

## ✏ Git Close
- close #69 
