### PR TITLE
Chore: 테스트 실패시 깃액션 실패하도록 main push 이외의 상황에도 적용

### DIFF
--- a/.github/workflows/azure-dev.yml
+++ b/.github/workflows/azure-dev.yml
@@ -101,10 +101,10 @@ jobs:
         report_paths: '**/test-results/*.xml'
         github_token: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: ❌ Fail Workflow if Tests Failed on Main Push
-      if: github.event_name == 'push' && github.ref == 'refs/heads/main' && steps.test-status.outputs.tests_passed == 'false'
+    - name: ❌ Fail Workflow if Tests Failed
+      if: steps.test-status.outputs.tests_passed == 'false'
       run: |
-        echo "Tests failed on main branch push. Failing the workflow."
+        echo "Tests failed. Failing the workflow."
         exit 1
 
     - name: 🚀 Log in with Azure (Federated Credentials)


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- #82 

## 📝 작업 내용
- 테스트 실패시 깃액션 실패하도록 main push 이외의 상황에도 적용

## 💬 리뷰 요구사항(선택)
현재 MCP 작업중에 필요한 워크플로우인

```
- name: 🧑‍💻 Checkout MCP Server
  uses: actions/checkout@v4
  with:
    repository: microsoft/markitdown
    path: src/InterviewAssistant.McpMarkItDown
```
위 작업의 경우 MCP 서버 머지 과정에서 적절하게 처리될 수 있도록 하기위해 해당 pr에서는 넣지 않았습니다


## ⏰ 현재 버그
x

## ✏ Git Close
> close #82
